### PR TITLE
Convert to Slice if Project Tags are passed comma separated

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,9 @@
 package config
 
-import "errors"
+import (
+	"errors"
+	"strings"
+)
 
 type Config struct {
 	BaseURL string
@@ -14,6 +17,10 @@ type Config struct {
 var ErrAPIKeyIsRequired = errors.New("api-key is required")
 
 func New(baseURL, apiKey, projectName, projectVersion string, projectTags []string) *Config {
+	if len(projectTags) == 1 && strings.Contains(projectTags[0], ",") {
+		projectTags = strings.Split(projectTags[0], ",")
+	}
+
 	return &Config{
 		BaseURL:        baseURL,
 		APIKey:         apiKey,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -35,6 +35,23 @@ func TestNew(t *testing.T) {
 				ProjectTags:    []string{"tag1", "tag2"},
 			},
 		},
+		{
+			name: "success tag separator is comma",
+			args: args{
+				baseURL:        "https://example.com",
+				apiKey:         "12345",
+				projectName:    "test-project",
+				projectVersion: "1.0.0",
+				projectTags:    []string{"tag1,tag2"},
+			},
+			want: &Config{
+				BaseURL:        "https://example.com",
+				APIKey:         "12345",
+				ProjectName:    "test-project",
+				ProjectVersion: "1.0.0",
+				ProjectTags:    []string{"tag1", "tag2"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fix https://github.com/takumakume/sbomreport-to-dependencytrack/issues/3

## current

### Cli options: OK
```
cat sbomreport.json | ./sbomreport-to-dependencytrack --project-tags tag-a --project-tags tag-b
```

tags: `tag-a` , `tag-b`


### Env var: Fail
```
cat sbomreport.json | DT_PROJECT_TAGS=tag-a,tag-b ./sbomreport-to-dependencytrack
```

tags: `tag-a,tag-b`

## before

```
cat sbomreport.json | DT_PROJECT_TAGS=tag-a,tag-b ./sbomreport-to-dependencytrack
```

tags: `tag-a` , `tag-b`